### PR TITLE
Upgrade SDK from v5.0.1 to v5.0.2

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -73,7 +73,7 @@ repositories {
 dependencies {
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'  // From node_modules
-    implementation "com.helpscout:beacon:5.0.1"
+    implementation "com.helpscout:beacon:5.0.2"
 }
 
 def configureReactNativePom(def pom) {


### PR DESCRIPTION
This PR should address and issue on Android when AGP >= `8.2.0`. This is aligned with [a fix released on the Help Scout's SDK](https://github.com/helpscout/beacon-android-sdk-sample/blob/main/CHANGELOG.md#version-502-2024-02-14).